### PR TITLE
CARRY: HACK: don't use managed identity on ARO

### DIFF
--- a/pkg/asset/manifests/azure/cloudproviderconfig.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig.go
@@ -16,8 +16,6 @@ type CloudProviderConfig struct {
 	NetworkSecurityGroupName string
 	VirtualNetworkName       string
 	SubnetName               string
-	AADClientID              string
-	AADClientSecret          string
 	ARO                      bool
 }
 
@@ -54,9 +52,10 @@ func (params CloudProviderConfig) JSON() (string, error) {
 	}
 
 	if params.ARO {
+		// ARO uses CloudConfigType=Merge and secret in kube-system namespace
+		// to create final configuration. Secret and configuration will be
+		// merged on controller startup
 		config.authConfig.UseManagedIdentityExtension = false
-		config.authConfig.AADClientID = params.AADClientID
-		config.authConfig.AADClientSecret = params.AADClientSecret
 	}
 
 	buff := &bytes.Buffer{}

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -125,10 +125,6 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			SubnetName:               subnet,
 			ARO:                      installConfig.Config.Azure.ARO,
 		}
-		if platformCreds.Azure != nil {
-			config.AADClientID = platformCreds.Azure.ClientID
-			config.AADClientSecret = platformCreds.Azure.ClientSecret
-		}
 		azureConfig, err := config.JSON()
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")


### PR DESCRIPTION
At the moment OCP on Azure uses MSI for kubelets and controllers and one or
more service principals for operators.  For now on ARO, simplify to all
components using the user-provided SP.  Later, we'll reinstate a separate
managed identity at least for worker kubelets.