### PR TITLE
fix bootstrap certificates

### DIFF
--- a/pkg/asset/tls/tls.go
+++ b/pkg/asset/tls/tls.go
@@ -115,7 +115,7 @@ func SignedCertificate(
 		Version:               3,
 		BasicConstraintsValid: true,
 	}
-	pub := caCert.PublicKey.(*rsa.PublicKey)
+	pub := key.Public()
 	certTmpl.SubjectKeyId, err = generateSubjectKeyID(pub)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to set subject key identifier")


### PR DESCRIPTION
CARRY: use the correct public key for certificate SubjectKeyId
Work around for https://bugzilla.redhat.com/show_bug.cgi?id=1831760