### PR TITLE
Changing ExecStop to ExecStopPost to handle cases when the dnsmasq fails during startup.

### DIFF
--- a/pkg/aro/dnsmasq/dnsmasq.go
+++ b/pkg/aro/dnsmasq/dnsmasq.go
@@ -38,7 +38,7 @@ Before=bootkube.service
 [Service]
 ExecStartPre=/bin/bash -c '/bin/cp /etc/resolv.conf /etc/resolv.conf.dnsmasq; /bin/sed -ni -e "/^nameserver /!p; \\$$a nameserver $$(hostname -I)" /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
 ExecStart=/usr/sbin/dnsmasq -k
-ExecStop=/bin/bash -c '/bin/mv /etc/resolv.conf.dnsmasq /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
+ExecStopPost=/bin/bash -c '/bin/mv /etc/resolv.conf.dnsmasq /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
 Restart=always
 
 [Install]


### PR DESCRIPTION
see https://www.freedesktop.org/software/systemd/man/systemd.service.html for the difference
ExecStop won't clean up if startup of dnsmasq fails for any reason.