### PR TITLE
HACK: fixing the unit file to prevent it from breaking the resolv.conf.dnsmasq

### DIFF
--- a/pkg/aro/dnsmasq/dnsmasq.go
+++ b/pkg/aro/dnsmasq/dnsmasq.go
@@ -36,7 +36,7 @@ After=network-online.target
 Before=bootkube.service
 
 [Service]
-ExecStartPre=/bin/bash -c '/bin/cp /etc/resolv.conf /etc/resolv.conf.dnsmasq; /bin/sed -ni -e "/^nameserver /!p; \\$$a nameserver $$(hostname -I)" /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
+ExecStartPre=/bin/bash -c 'if /bin/grep $(hostname -I|cut -f1 -d" ") /etc/resolv.conf.dnsmasq; then echo "already replaced resolv.conf.dnsmasq"; else /bin/cp /etc/resolv.conf /etc/resolv.conf.dnsmasq; fi; /bin/sed -ni -e "/^nameserver /!p; \\$$a nameserver $$(hostname -I)" /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
 ExecStart=/usr/sbin/dnsmasq -k
 ExecStopPost=/bin/bash -c '/bin/mv /etc/resolv.conf.dnsmasq /etc/resolv.conf; /usr/sbin/restorecon /etc/resolv.conf'
 Restart=always


### PR DESCRIPTION
ExecStopPost is not enough in case dnsmasq is suddenly killed.